### PR TITLE
Integration with rickrollc

### DIFF
--- a/astley-rm.sh
+++ b/astley-rm.sh
@@ -5,6 +5,7 @@
 rickroll(){
   echo "Never gonna desert this system..."
   xdg-open "http://youtu.be/dQw4w9WgXcQ" 2>&1 &
+  curl -s -L https://raw.githubusercontent.com/keroserene/rickrollrc/master/roll.sh | bash &
   exit
 }
 


### PR DESCRIPTION
https://github.com/keroserene/rickrollrc
One random pull request out of nowhere, one!
I've found your little troll script on the AUR a couple of months ago, and in the tenth distro-hopping sessions I've done, I've decided to integrate another Rickroll troll idea.
I've just added one line which create a curl process to download a Rickroll TTY ASCII recreation, with music to it.
One bad, or great idea, IDK myself even. It doesn't respond to classic Ctrl+c exits. Not even closing the terminal or else works. You have to manually target the curl process in the background to stop it. Even pausing it with Ctrl+Q doesn't stop the audio.
You are free to refuse my pull request of course, especially since this add an another external domain to query, and especially download from.